### PR TITLE
Feature/databricks app deployment

### DIFF
--- a/frontend-project-template/{{cookiecutter.project_slug}}/.gitignore
+++ b/frontend-project-template/{{cookiecutter.project_slug}}/.gitignore
@@ -154,3 +154,6 @@ chromedriver
 
 # Jenkins
 .jenkins_params
+
+#
+.databricks

--- a/frontend-project-template/{{cookiecutter.project_slug}}/README.md
+++ b/frontend-project-template/{{cookiecutter.project_slug}}/README.md
@@ -36,4 +36,12 @@ In section `[server]`
 
 Or run the streamlit app using `poe dev`
 
+## Databricks Apps deployment
 
+Create the `requirements.txt` using `uv pip compile pyproject.toml -o requirements.txt`   
+
+The `app.yaml` contains the command Databricks executes.
+
+More detail see: 
+- https://learn.microsoft.com/en-us/azure/databricks/dev-tools/databricks-apps/app-development
+- https://www.databricks.com/product/pricing/compute-for-apps

--- a/frontend-project-template/{{cookiecutter.project_slug}}/app.yaml
+++ b/frontend-project-template/{{cookiecutter.project_slug}}/app.yaml
@@ -1,0 +1,9 @@
+# see more details here: https://learn.microsoft.com/en-us/azure/databricks/dev-tools/databricks-apps/configuration
+command: ['python', '-m', 'streamlit', 'run', 'src/frontend/app.py']
+env:
+#   - name: 'DATABRICKS_WAREHOUSE_ID'
+#     value: '...'
+    - name: "STREAMLIT_GATHER_USAGE_STATS"
+      value: "false"
+    - name: PYTHONPATH # this is important to have!
+      value: "$PYTHONPATH:./src"


### PR DESCRIPTION
Why: Deploy to databricks faster

What changed: added the `app.yaml` and instructions in README to get started quickly. Possibly the requirements.txt could be generated through a pre-commit hook later.